### PR TITLE
Add the environmental specifications of argparse.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Requirements
 =====
 cx-Oracle==5.1.2
 
+python-argparse
+
+Note:Try installing python-argparse: `easy_install argparse`  or  `yum install python-argarse` on RHEL/Centos.
+
 Tested with python 2.6 and 2.7
 
 Create Oracle user for Pyora usage


### PR DESCRIPTION
It will throw an error message like below if you have not install python-argparse.
"Traceback (most recent call last):
  File "pyora.py", line 10, in <module>
    import argparse,cx_Oracle"